### PR TITLE
Add failure rate simulation analysis tooling and dashboard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@
 **/__pycache__
 data/
 *.json
+!contrib/failure_rate_sample_input.json
+!static/failure_rate_sample_report.json
 *.params
 *.DS_Store
 *.csv

--- a/contrib/failure_rate_sample_input.json
+++ b/contrib/failure_rate_sample_input.json
@@ -1,0 +1,49 @@
+{
+  "resources": [
+    {"name": "AGV-1", "failure_rate_per_hour": 0.004},
+    {"name": "Transfer-Car", "failure_rate_per_hour": 0.0035},
+    {"name": "Palletizer", "failure_rate_per_hour": 0.0025}
+  ],
+  "runs": [
+    {
+      "run_id": "sim-001",
+      "usage_hours": {
+        "AGV-1": 1.25,
+        "Transfer-Car": 0.80,
+        "Palletizer": 0.60
+      }
+    },
+    {
+      "run_id": "sim-002",
+      "usage_hours": {
+        "AGV-1": 0.95,
+        "Transfer-Car": 0.40,
+        "Palletizer": 0.55
+      }
+    },
+    {
+      "run_id": "sim-003",
+      "usage_hours": {
+        "AGV-1": 1.60,
+        "Transfer-Car": 1.10,
+        "Palletizer": 0.70
+      }
+    },
+    {
+      "run_id": "sim-004",
+      "usage_hours": {
+        "AGV-1": 0.75,
+        "Transfer-Car": 0.30,
+        "Palletizer": 0.00
+      }
+    },
+    {
+      "run_id": "sim-005",
+      "usage_hours": {
+        "AGV-1": 1.40,
+        "Transfer-Car": 0.90,
+        "Palletizer": 0.65
+      }
+    }
+  ]
+}

--- a/contrib/failure_rate_simulation.py
+++ b/contrib/failure_rate_simulation.py
@@ -1,0 +1,263 @@
+"""工具：面向流程型保障效能仿真计算的资源故障概率分析。
+
+该脚本接受一个JSON输入文件，其中描述了仿真的资源及其每个小时的故障率
+（例如0.004代表0.4%的故障率），以及多次仿真运行中各资源的使用时长（单位：
+小时）。
+
+脚本会对每个资源计算：
+* 每次仿真运行期间发生故障的概率；
+* 多次仿真综合后至少出现一次故障的概率；
+* 期望故障次数；
+* 累计使用时长、参与仿真的次数等指标；
+并输出为结构化的JSON，方便前端可视化。
+
+用法示例::
+
+    python contrib/failure_rate_simulation.py \
+        --input contrib/failure_rate_sample_input.json \
+        --output static/failure_rate_sample_report.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Dict, Iterable, List, Mapping, MutableMapping, Optional
+
+
+def _round_float(value: float, digits: int = 10) -> float:
+    """对浮点数进行四舍五入，避免JSON中出现冗长的小数。"""
+
+    return round(float(value), digits)
+
+
+def _validate_failure_rate(value: float) -> float:
+    """Validate that the failure rate is between 0 and 1."""
+    if value < 0:
+        raise ValueError("资源的故障率必须大于等于0")
+    if value >= 1:
+        raise ValueError("资源的故障率必须小于1（代表每小时100%故障）")
+    return float(value)
+
+
+@dataclass(frozen=True)
+class Resource:
+    """Represent a simulated resource with an hourly failure probability."""
+
+    name: str
+    failure_rate_per_hour: float
+
+    def __post_init__(self) -> None:
+        _validate_failure_rate(self.failure_rate_per_hour)
+
+    @property
+    def hazard_rate(self) -> float:
+        """Return the continuous-time hazard rate derived from per-hour failure rate.
+
+        我们假设每小时的故障率描述的是离散时间内发生故障的概率，为了支持任意
+        时长的使用区间，将其转换为指数分布的瞬时失效率（hazard rate）：
+
+            hazard = -ln(1 - p_hour)
+        """
+
+        if self.failure_rate_per_hour == 0:
+            return 0.0
+        return -math.log1p(-self.failure_rate_per_hour)
+
+    def failure_probability(self, usage_hours: float) -> float:
+        """Probability that the resource fails during `usage_hours` of activity."""
+
+        if usage_hours < 0:
+            raise ValueError("资源使用时长不能为负数")
+        if usage_hours == 0 or self.failure_rate_per_hour == 0:
+            return 0.0
+        hazard = self.hazard_rate
+        return 1.0 - math.exp(-hazard * usage_hours)
+
+
+@dataclass(frozen=True)
+class SimulationRun:
+    """Represent a single simulation execution and per-resource usage."""
+
+    run_id: str
+    usage_hours: Mapping[str, float]
+
+
+class ResourceAccumulator:
+    """Accumulate run statistics for a resource before producing a report."""
+
+    def __init__(self, resource: Resource) -> None:
+        self.resource = resource
+        self.total_usage: float = 0.0
+        self.exposure_count: int = 0
+        self._per_run_entries: List[MutableMapping[str, float]] = []
+
+    def add_run(self, run: SimulationRun) -> None:
+        usage_hours = float(run.usage_hours.get(self.resource.name, 0.0))
+        if usage_hours < 0:
+            raise ValueError(
+                f"仿真运行 {run.run_id} 中资源 {self.resource.name} 的使用时长不能为负数"
+            )
+        if usage_hours == 0:
+            return
+        failure_probability = self.resource.failure_probability(usage_hours)
+        self.total_usage += usage_hours
+        self.exposure_count += 1
+        self._per_run_entries.append(
+            {
+                "run_id": run.run_id,
+                "usage_hours": usage_hours,
+                "failure_probability": failure_probability,
+            }
+        )
+
+    def build_summary(self) -> Mapping[str, object]:
+        if not self._per_run_entries:
+            return {
+                "name": self.resource.name,
+                "failure_rate_per_hour": self.resource.failure_rate_per_hour,
+                "total_usage_hours": 0.0,
+                "exposure_count": 0,
+                "expected_failures": 0.0,
+                "overall_failure_probability": 0.0,
+                "average_failure_probability": 0.0,
+                "per_run": [],
+            }
+
+        probabilities = [entry["failure_probability"] for entry in self._per_run_entries]
+        expected_failures = float(sum(probabilities))
+        survival_product = 1.0
+        for probability in probabilities:
+            survival_product *= 1.0 - probability
+        overall_failure_probability = 1.0 - survival_product
+        average_failure_probability = expected_failures / self.exposure_count
+
+        per_run_entries = [
+            {
+                "run_id": entry["run_id"],
+                "usage_hours": _round_float(entry["usage_hours"], 6),
+                "failure_probability": _round_float(entry["failure_probability"], 10),
+            }
+            for entry in self._per_run_entries
+        ]
+
+        return {
+            "name": self.resource.name,
+            "failure_rate_per_hour": self.resource.failure_rate_per_hour,
+            "total_usage_hours": _round_float(self.total_usage, 6),
+            "exposure_count": self.exposure_count,
+            "expected_failures": _round_float(expected_failures, 10),
+            "overall_failure_probability": _round_float(
+                overall_failure_probability, 10
+            ),
+            "average_failure_probability": _round_float(
+                average_failure_probability, 10
+            ),
+            "per_run": per_run_entries,
+        }
+
+
+class FailureAnalyzer:
+    """Compute failure probabilities across multiple simulation runs."""
+
+    def __init__(self, resources: Iterable[Resource]):
+        resource_map = {resource.name: resource for resource in resources}
+        if not resource_map:
+            raise ValueError("至少需要一个资源来计算故障率")
+        self._resource_map = resource_map
+
+    def generate_report(self, runs: Iterable[SimulationRun]) -> Mapping[str, object]:
+        accumulators: Dict[str, ResourceAccumulator] = {
+            name: ResourceAccumulator(resource)
+            for name, resource in self._resource_map.items()
+        }
+        run_count = 0
+        for run in runs:
+            run_count += 1
+            for accumulator in accumulators.values():
+                accumulator.add_run(run)
+        if run_count == 0:
+            raise ValueError("至少需要一条仿真运行记录")
+
+        resource_summaries = [
+            accumulators[name].build_summary() for name in self._resource_map
+        ]
+
+        return {
+            "generated_at": datetime.now(timezone.utc).isoformat(),
+            "total_runs": run_count,
+            "resources": resource_summaries,
+            "assumptions": {
+                "故障率定义": "failure_rate_per_hour 表示每使用一小时发生故障的概率",
+                "时间建模": "将离散故障率转换为指数分布失效率，以支持任意时长的使用",
+            },
+        }
+
+
+def load_input(path: Path) -> Mapping[str, object]:
+    with path.open("r", encoding="utf-8") as f:
+        data = json.load(f)
+    if "resources" not in data or "runs" not in data:
+        raise ValueError("输入JSON必须包含 resources 和 runs 字段")
+    return data
+
+
+def parse_resources(raw_resources: Iterable[Mapping[str, object]]) -> List[Resource]:
+    resources = []
+    for item in raw_resources:
+        try:
+            name = str(item["name"])
+            failure_rate = _validate_failure_rate(float(item["failure_rate_per_hour"]))
+        except KeyError as exc:
+            raise KeyError(f"资源定义缺少字段: {exc}") from exc
+        resources.append(Resource(name=name, failure_rate_per_hour=failure_rate))
+    return resources
+
+
+def parse_runs(raw_runs: Iterable[Mapping[str, object]]) -> List[SimulationRun]:
+    runs: List[SimulationRun] = []
+    for index, item in enumerate(raw_runs, start=1):
+        run_id = str(item.get("run_id", f"run_{index:03d}"))
+        usage_hours_raw = item.get("usage_hours")
+        if not isinstance(usage_hours_raw, Mapping):
+            raise TypeError(f"仿真运行 {run_id} 的 usage_hours 必须是对象")
+        usage_hours: Dict[str, float] = {}
+        for resource_name, value in usage_hours_raw.items():
+            usage_hours[str(resource_name)] = float(value)
+        runs.append(SimulationRun(run_id=run_id, usage_hours=usage_hours))
+    return runs
+
+
+def build_report(input_path: Path) -> Mapping[str, object]:
+    raw_data = load_input(input_path)
+    resources = parse_resources(raw_data.get("resources", []))
+    runs = parse_runs(raw_data.get("runs", []))
+    analyzer = FailureAnalyzer(resources)
+    return analyzer.generate_report(runs)
+
+
+def main(argv: Optional[List[str]] = None) -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--input", required=True, type=Path, help="包含资源定义与仿真记录的JSON文件")
+    parser.add_argument("--output", type=Path, help="输出统计结果的JSON路径，缺省时打印到stdout")
+    parser.add_argument("--indent", type=int, default=2, help="输出JSON的缩进，默认为2")
+    args = parser.parse_args(argv)
+
+    report = build_report(args.input)
+    output_text = json.dumps(report, indent=args.indent, ensure_ascii=False)
+
+    if args.output:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        with args.output.open("w", encoding="utf-8") as f:
+            f.write(output_text)
+            f.write("\n")
+    else:
+        print(output_text)
+
+
+if __name__ == "__main__":
+    main()

--- a/static/failure_rate_dashboard.html
+++ b/static/failure_rate_dashboard.html
@@ -1,0 +1,329 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+  <head>
+    <meta charset="utf-8" />
+    <title>资源故障率仿真分析示例</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <link
+      rel="stylesheet"
+      href="https://fonts.googleapis.com/css2?family=Noto+Sans+SC:wght@400;600&display=swap"
+    />
+    <style>
+      :root {
+        color-scheme: light dark;
+      }
+      body {
+        font-family: "Noto Sans SC", system-ui, -apple-system, BlinkMacSystemFont,
+          "Segoe UI", sans-serif;
+        margin: 0;
+        padding: 2rem 1rem 4rem;
+        background: #f5f7fb;
+        color: #202124;
+      }
+      h1,
+      h2 {
+        text-align: center;
+        font-weight: 600;
+      }
+      h1 {
+        margin-bottom: 0.5rem;
+      }
+      h2 {
+        margin-top: 2.5rem;
+        font-size: 1.4rem;
+      }
+      p.description {
+        text-align: center;
+        margin: 0 auto 2rem;
+        max-width: 60ch;
+        line-height: 1.6;
+      }
+      .summary-card {
+        background: white;
+        border-radius: 16px;
+        box-shadow: 0 15px 35px rgba(31, 89, 222, 0.12);
+        padding: 1.5rem;
+        margin: 0 auto 2rem;
+        max-width: 960px;
+      }
+      .summary-grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+        gap: 1.25rem;
+      }
+      .summary-item {
+        background: linear-gradient(135deg, rgba(45, 126, 255, 0.12), rgba(45, 126, 255, 0));
+        border-radius: 12px;
+        padding: 1rem;
+      }
+      .summary-item h3 {
+        margin: 0;
+        font-size: 1rem;
+        color: #1a3d8f;
+      }
+      .summary-item p {
+        margin: 0.25rem 0 0;
+        font-size: 1.4rem;
+        font-weight: 600;
+      }
+      table {
+        border-collapse: collapse;
+        width: 100%;
+      }
+      th,
+      td {
+        border-bottom: 1px solid rgba(31, 89, 222, 0.15);
+        padding: 0.75rem;
+        text-align: center;
+      }
+      th {
+        font-size: 0.9rem;
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+        color: #1a3d8f;
+      }
+      tbody tr:hover {
+        background: rgba(45, 126, 255, 0.08);
+      }
+      .charts {
+        display: grid;
+        gap: 2rem;
+        margin-top: 2rem;
+      }
+      canvas {
+        background: white;
+        border-radius: 16px;
+        box-shadow: 0 15px 35px rgba(31, 89, 222, 0.12);
+        padding: 1rem;
+      }
+      .footer {
+        margin-top: 3rem;
+        font-size: 0.9rem;
+        text-align: center;
+        color: #5f6368;
+      }
+      @media (prefers-color-scheme: dark) {
+        body {
+          background: #10141c;
+          color: #e8eaed;
+        }
+        .summary-card,
+        canvas {
+          background: #1f2733;
+          box-shadow: none;
+        }
+        th,
+        td {
+          border-color: rgba(255, 255, 255, 0.08);
+        }
+        tbody tr:hover {
+          background: rgba(80, 132, 255, 0.18);
+        }
+      }
+    </style>
+    <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.7/dist/chart.umd.min.js"></script>
+  </head>
+  <body>
+    <h1>保障效能仿真 · 资源故障率分析</h1>
+    <p class="description">
+      该示例展示了如何基于多次流程仿真运行，汇总各类资源的使用时长与故障率，
+      得出资源级别的综合故障概率与期望故障次数。页面所用数据来源于
+      <code>failure_rate_sample_report.json</code>，可替换成后台实际计算的统计结果。
+    </p>
+
+    <section id="summary" class="summary-card" hidden>
+      <div class="summary-grid">
+        <div class="summary-item">
+          <h3>统计时间</h3>
+          <p id="summary-generated"></p>
+        </div>
+        <div class="summary-item">
+          <h3>仿真轮次</h3>
+          <p id="summary-runs"></p>
+        </div>
+        <div class="summary-item">
+          <h3>资源数量</h3>
+          <p id="summary-resources"></p>
+        </div>
+      </div>
+    </section>
+
+    <section class="summary-card" style="overflow-x: auto">
+      <table id="resource-table">
+        <thead>
+          <tr>
+            <th>资源</th>
+            <th>每小时故障率</th>
+            <th>累计使用时长 (h)</th>
+            <th>参与仿真次数</th>
+            <th>期望故障次数</th>
+            <th>综合故障概率</th>
+          </tr>
+        </thead>
+        <tbody></tbody>
+      </table>
+    </section>
+
+    <section class="charts summary-card">
+      <h2>综合故障概率 (单位：%)</h2>
+      <canvas id="probability-chart" height="280"></canvas>
+      <h2>期望故障次数</h2>
+      <canvas id="expected-chart" height="280"></canvas>
+    </section>
+
+    <footer class="footer" id="footer"></footer>
+
+    <script>
+      const REPORT_URL = "failure_rate_sample_report.json";
+
+      function formatPercent(value, fractionDigits = 2) {
+        return `${(value * 100).toFixed(fractionDigits)}%`;
+      }
+
+      function formatNumber(value, fractionDigits = 2) {
+        return Number.parseFloat(value).toFixed(fractionDigits);
+      }
+
+      function setSummary(report) {
+        const summarySection = document.getElementById("summary");
+        document.getElementById("summary-generated").textContent = new Date(
+          report.generated_at
+        ).toLocaleString();
+        document.getElementById("summary-runs").textContent = report.total_runs;
+        document.getElementById("summary-resources").textContent =
+          report.resources.length;
+        summarySection.hidden = false;
+      }
+
+      function populateTable(resources) {
+        const tbody = document.querySelector("#resource-table tbody");
+        tbody.textContent = "";
+        for (const resource of resources) {
+          const tr = document.createElement("tr");
+
+          const cells = [
+            resource.name,
+            formatPercent(resource.failure_rate_per_hour, 2),
+            formatNumber(resource.total_usage_hours),
+            resource.exposure_count,
+            formatNumber(resource.expected_failures, 4),
+            formatPercent(resource.overall_failure_probability, 2),
+          ];
+
+          for (const value of cells) {
+            const td = document.createElement("td");
+            td.textContent = value;
+            tr.appendChild(td);
+          }
+          tbody.appendChild(tr);
+        }
+      }
+
+      function buildProbabilityChart(resources) {
+        const ctx = document.getElementById("probability-chart").getContext("2d");
+        return new Chart(ctx, {
+          type: "bar",
+          data: {
+            labels: resources.map((r) => r.name),
+            datasets: [
+              {
+                label: "综合故障概率",
+                data: resources.map((r) => r.overall_failure_probability * 100),
+                backgroundColor: "rgba(45, 126, 255, 0.7)",
+                borderRadius: 8,
+              },
+            ],
+          },
+          options: {
+            responsive: true,
+            plugins: {
+              legend: { display: false },
+              tooltip: {
+                callbacks: {
+                  label: (context) =>
+                    `${context.dataset.label}: ${context.parsed.y.toFixed(3)}%`,
+                },
+              },
+            },
+            scales: {
+              y: {
+                title: { display: true, text: "概率 (%)" },
+                beginAtZero: true,
+              },
+            },
+          },
+        });
+      }
+
+      function buildExpectedChart(resources) {
+        const ctx = document.getElementById("expected-chart").getContext("2d");
+        return new Chart(ctx, {
+          type: "bar",
+          data: {
+            labels: resources.map((r) => r.name),
+            datasets: [
+              {
+                label: "期望故障次数",
+                data: resources.map((r) => r.expected_failures),
+                backgroundColor: "rgba(255, 171, 64, 0.7)",
+                borderRadius: 8,
+              },
+            ],
+          },
+          options: {
+            responsive: true,
+            plugins: {
+              legend: { display: false },
+              tooltip: {
+                callbacks: {
+                  label: (context) =>
+                    `${context.dataset.label}: ${context.parsed.y.toFixed(4)}`,
+                },
+              },
+            },
+            scales: {
+              y: {
+                title: { display: true, text: "次数" },
+                beginAtZero: true,
+              },
+            },
+          },
+        });
+      }
+
+      function setFooter(assumptions = {}) {
+        const footer = document.getElementById("footer");
+        const entries = Object.entries(assumptions);
+        if (!entries.length) {
+          footer.textContent = "";
+          return;
+        }
+        const lines = entries.map(
+          ([key, value]) => `${key.replace(/_/g, " ")}: ${value}`
+        );
+        footer.textContent = `建模假设：${lines.join("；")}`;
+      }
+
+      async function bootstrap() {
+        try {
+          const response = await fetch(REPORT_URL);
+          if (!response.ok) {
+            throw new Error(`无法加载 ${REPORT_URL} (${response.status})`);
+          }
+          const report = await response.json();
+          setSummary(report);
+          populateTable(report.resources);
+          buildProbabilityChart(report.resources);
+          buildExpectedChart(report.resources);
+          setFooter(report.assumptions);
+        } catch (error) {
+          const container = document.querySelector("#resource-table tbody");
+          container.innerHTML = `<tr><td colspan="6">数据加载失败：${error.message}</td></tr>`;
+          console.error(error);
+        }
+      }
+
+      bootstrap();
+    </script>
+  </body>
+</html>

--- a/static/failure_rate_sample_report.json
+++ b/static/failure_rate_sample_report.json
@@ -1,0 +1,113 @@
+{
+  "generated_at": "2025-09-19T00:53:12.015188+00:00",
+  "total_runs": 5,
+  "resources": [
+    {
+      "name": "AGV-1",
+      "failure_rate_per_hour": 0.004,
+      "total_usage_hours": 5.95,
+      "exposure_count": 5,
+      "expected_failures": 0.0237872128,
+      "overall_failure_probability": 0.0235656173,
+      "average_failure_probability": 0.0047574426,
+      "per_run": [
+        {
+          "run_id": "sim-001",
+          "usage_hours": 1.25,
+          "failure_probability": 0.0049974975
+        },
+        {
+          "run_id": "sim-002",
+          "usage_hours": 0.95,
+          "failure_probability": 0.0038003805
+        },
+        {
+          "run_id": "sim-003",
+          "usage_hours": 1.6,
+          "failure_probability": 0.0063923159
+        },
+        {
+          "run_id": "sim-004",
+          "usage_hours": 0.75,
+          "failure_probability": 0.0030015025
+        },
+        {
+          "run_id": "sim-005",
+          "usage_hours": 1.4,
+          "failure_probability": 0.0055955164
+        }
+      ]
+    },
+    {
+      "name": "Transfer-Car",
+      "failure_rate_per_hour": 0.0035,
+      "total_usage_hours": 3.5,
+      "exposure_count": 5,
+      "expected_failures": 0.0122536204,
+      "overall_failure_probability": 0.0121965,
+      "average_failure_probability": 0.0024507241,
+      "per_run": [
+        {
+          "run_id": "sim-001",
+          "usage_hours": 0.8,
+          "failure_probability": 0.0028009814
+        },
+        {
+          "run_id": "sim-002",
+          "usage_hours": 0.4,
+          "failure_probability": 0.0014014728
+        },
+        {
+          "run_id": "sim-003",
+          "usage_hours": 1.1,
+          "failure_probability": 0.0038493255
+        },
+        {
+          "run_id": "sim-004",
+          "usage_hours": 0.3,
+          "failure_probability": 0.0010512888
+        },
+        {
+          "run_id": "sim-005",
+          "usage_hours": 0.9,
+          "failure_probability": 0.003150552
+        }
+      ]
+    },
+    {
+      "name": "Palletizer",
+      "failure_rate_per_hour": 0.0025,
+      "total_usage_hours": 2.5,
+      "exposure_count": 4,
+      "expected_failures": 0.006252894,
+      "overall_failure_probability": 0.0062382861,
+      "average_failure_probability": 0.0015632235,
+      "per_run": [
+        {
+          "run_id": "sim-001",
+          "usage_hours": 0.6,
+          "failure_probability": 0.0015007509
+        },
+        {
+          "run_id": "sim-002",
+          "usage_hours": 0.55,
+          "failure_probability": 0.0013757744
+        },
+        {
+          "run_id": "sim-003",
+          "usage_hours": 0.7,
+          "failure_probability": 0.001750657
+        },
+        {
+          "run_id": "sim-005",
+          "usage_hours": 0.65,
+          "failure_probability": 0.0016257117
+        }
+      ]
+    }
+  ],
+  "assumptions": {
+    "故障率定义": "failure_rate_per_hour 表示每使用一小时发生故障的概率",
+    "时间建模": "将离散故障率转换为指数分布失效率，以支持任意时长的使用"
+  }
+}


### PR DESCRIPTION
## Summary
- add a Python CLI that aggregates per-resource failure probabilities across multiple simulation runs and outputs JSON reports
- provide sample simulation input/output data and allow the JSON artefacts to be checked into version control
- build a static Chart.js dashboard that visualises the aggregated failure metrics for quick inspection

## Testing
- python contrib/failure_rate_simulation.py --input contrib/failure_rate_sample_input.json --output static/failure_rate_sample_report.json
- python -m compileall contrib/failure_rate_simulation.py


------
https://chatgpt.com/codex/tasks/task_e_68cca7f0bfe8832694c8001bb34143aa